### PR TITLE
tee/prototype: Return processing errors for ProcessTXs/Blocks

### DIFF
--- a/tee/prototype/blockproc.go
+++ b/tee/prototype/blockproc.go
@@ -7,24 +7,24 @@ import (
 	"fmt"
 
 	log "github.com/sirupsen/logrus"
-
-	"github.com/perun-network/erdstall/tee"
 )
 
 func (e *Enclave) blockProcessor(
-	newBlocks <-chan *tee.Block,
-	verifiedBlocks chan<- *tee.Block,
+	newBlocks <-chan blockReq,
+	verifiedBlocks chan<- blockReq,
 ) error {
-	k := e.params.PowDepth
 	log.Debug("blockProc: starting...")
-	for b := range newBlocks {
-		if e.bc.Len() == 0 && e.params.InitBlock != b.NumberU64() {
-			return fmt.Errorf("first block (%d) not initial Erdstall block (%d)", b.NumberU64(), e.params.InitBlock)
+
+	process := func(b blockReq) (error, bool) {
+		k := e.params.PowDepth
+
+		if n := b.block.NumberU64(); e.bc.Len() == 0 && e.params.InitBlock != n {
+			return fmt.Errorf("first block (%d) not initial Erdstall block (%d)", n, e.params.InitBlock), true
 		}
 
-		// verify block chain
-		if err := e.bc.PushVerify(b); err != nil {
-			return fmt.Errorf("pushing block to local blockchain: %w", err)
+		// verify blockchain
+		if err := e.bc.PushVerify(b.block); err != nil {
+			return fmt.Errorf("pushing block to local blockchain: %w", err), true
 		}
 
 		// TODO: * Handle Reorgs...
@@ -34,14 +34,26 @@ func (e *Enclave) blockProcessor(
 		l := e.bc.Len()
 		if l > k {
 			vblock := e.bc.blocks[l-k-1]
-			log.WithField("blockNum", vblock.NumberU64()).Trace("blockProc: forwarding block to epochProc")
-			verifiedBlocks <- vblock
+			log := log.WithField("blockNum", vblock.NumberU64())
+			log.Trace("blockProc: forwarding block to epochProc")
+			verifiedBlocks <- blockReq{block: vblock, result: b.result}
 			if e.params.IsLastPhaseBlock(vblock.NumberU64()) && !e.running.IsSet() {
 				// graceful shutdown
 				log.Info("blockProc: last verified phase block forwarded, shutting down")
-				return nil
+				return nil, true
 			}
 		}
+
+		return nil, false
 	}
+
+	for b := range newBlocks {
+		err, shutdown := process(b)
+		b.result <- err
+		if err != nil || shutdown {
+			return err
+		}
+	}
+
 	return errors.New("blockProc: newBlocks channel closed")
 }

--- a/tee/prototype/enclave_internal_test.go
+++ b/tee/prototype/enclave_internal_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	wtest "perun.network/go-perun/backend/ethereum/wallet/test"
 	"perun.network/go-perun/pkg/test"
 
 	cltest "github.com/perun-network/erdstall/client/test"
@@ -126,6 +125,11 @@ func TestEnclave(t *testing.T) {
 	requiree.NoError(bob.SendToClient(alice, eth.EthToWeiInt(10)))
 	requiree.NoError(alice.SendToClient(bob, eth.EthToWeiInt(2)))
 
+	// send invalid txs
+	errs := alice.SendInvalidTxs(rng, bob.Address())
+	for i, err := range errs {
+		requiree.Errorf(err, "expected invalid tx #%d", i)
+	}
 
 	seal("txPhase", params.PhaseDuration)
 

--- a/tee/prototype/epochproc.go
+++ b/tee/prototype/epochproc.go
@@ -404,8 +404,7 @@ func (e *Enclave) applyEpochTx(ep *Epoch, tx *tee.Transaction) error {
 	}
 
 	if tx.Epoch != ep.Number {
-		log.Errorf("txProc: wrong TX Epoch: expected %d, got %d", ep.Number, tx.Epoch)
-		return nil
+		return fmt.Errorf("wrong TX Epoch: expected %d, got %d", ep.Number, tx.Epoch)
 	}
 
 	sender, oks := ep.balances[tx.Sender]

--- a/tee/transaction.go
+++ b/tee/transaction.go
@@ -33,10 +33,19 @@ type TextSigner interface {
 	SignText(account accounts.Account, text []byte) ([]byte, error)
 }
 
+// Sign signs the transaction with the given account and signer. It checks that
+// the account matches the transaction's sender.
 func (t *Transaction) Sign(contract common.Address, account accounts.Account, w TextSigner) error {
 	if account.Address != t.Sender {
 		return errors.New("not Sender's account")
 	}
+	return t.SignAlien(contract, account, w)
+}
+
+// SignAlien signs the transaction with the given account and signer,
+// irrespective of who's the transaction's sender. Should only be used in
+// testing.
+func (t *Transaction) SignAlien(contract common.Address, account accounts.Account, w TextSigner) error {
 	msg, err := EncodeTransaction(contract, *t)
 	if err != nil {
 		return fmt.Errorf("encoding tx: %w", err)


### PR DESCRIPTION
Before, these functions just pushed the request into the processors'
queues and returned nil immediately. Now they block until all transactions
or blocks are processed and returns all errors, if any, that occurred
while processing.