### PR TITLE
Fix epoch merge

### DIFF
--- a/tee/prototype/epoch.go
+++ b/tee/prototype/epoch.go
@@ -74,7 +74,7 @@ func (e *Epoch) merge(p *Epoch) *Epoch {
 	mEpoch.balances = cloneBalances(p.balances)
 	for acc, bal := range e.balances {
 		if pBal, ok := mEpoch.balances[acc]; ok {
-			bal.Value.Add(bal.Value, pBal.Value)
+			pBal.Value.Add(bal.Value, pBal.Value)
 		} else {
 			mEpoch.balances[acc] = bal
 		}


### PR DESCRIPTION
Our Epoch-Merge method did not act on the correct balance. Thus we never applied changes that occurred due to extra deposits.