### PR TITLE
[operator] Fix rpc subscription

### DIFF
--- a/operator/rpcoperator.go
+++ b/operator/rpcoperator.go
@@ -27,7 +27,15 @@ type (
 		mtx     sync.Mutex // protects all
 		enclave tee.Enclave
 
-		subs map[common.Address]*ProofSub
+		subs map[common.Address]*BufferedProofSubs
+	}
+
+	// BufferedProofSub describes a slice of subs, which also holds the latest
+	// available deposit- and/or balance-proof.
+	BufferedProofSubs struct {
+		subs     []ProofSub
+		latestDP *tee.DepositProof
+		latestBP *tee.BalanceProof
 	}
 
 	// ProofSub is a subscription on TEE proofs.
@@ -43,7 +51,7 @@ var _ WireAPI = (*RPCOperator)(nil)
 func NewRPCOperator(enclave tee.Enclave) *RPCOperator {
 	return &RPCOperator{
 		enclave: enclave,
-		subs:    make(map[common.Address]*ProofSub),
+		subs:    make(map[common.Address]*BufferedProofSubs),
 	}
 }
 
@@ -60,64 +68,89 @@ func (o *RPCOperator) SubscribeProofs(addr common.Address) (ProofSub, error) {
 	o.mtx.Lock()
 	defer o.mtx.Unlock()
 	log.WithField("who", addr.Hex()).Debug("Subscribed to proofs")
-	sub, ok := o.subs[addr]
-	if !ok {
-		o.subscribe(addr)
-		sub = o.subs[addr]
-	}
-	return *sub, nil
+	sub := o.subscribe(addr)
+	return sub, nil
 }
 
 // subscribe is an internal implementation detail and should not be called.
 func (o *RPCOperator) subscribe(addr common.Address) ProofSub {
-	o.subs[addr] = newProofSub()
-	return *o.subs[addr]
+	sub := *newProofSub()
+	if _, ok := o.subs[addr]; !ok {
+		o.subs[addr] = new(BufferedProofSubs)
+	} else {
+		if dp := o.subs[addr].latestDP; dp != nil {
+			sub.deposits <- *dp
+		}
+		if bp := o.subs[addr].latestBP; bp != nil {
+			sub.balances <- *bp
+		}
+	}
+	o.subs[addr].subs = append(o.subs[addr].subs, sub)
+	return sub
 }
 
 func (o *RPCOperator) PushDepositProof(proof tee.DepositProof) {
 	o.mtx.Lock()
 	defer o.mtx.Unlock()
 	who := proof.Balance.Account
-	sub, ok := o.subs[who]
+	bufsub, ok := o.subs[who]
 	if !ok {
 		log.WithField("who", who.Hex()).Debug("Received DP without subscription - buffering")
-		o.subscribe(who)
-		sub = o.subs[who]
+		bufsub = new(BufferedProofSubs)
+		o.subs[who] = bufsub
 	}
-	// Clear out old buffered proof.
-	select {
-	case <-sub.deposits:
-	default:
+	bufsub.latestDP = &proof
+	subs := bufsub.subs
+
+	for i := 0; i < len(subs); i++ {
+		// Clear out old buffered proof.
+		select {
+		case <-subs[i].deposits:
+		default:
+		}
+		// Write new proof in.
+		select {
+		case <-subs[i].quit:
+			l := len(subs) - 1
+			subs[i] = subs[l]
+			subs = subs[:l]
+			i--
+		case subs[i].deposits <- proof:
+		}
 	}
-	// Write new proof in.
-	select {
-	case <-sub.quit:
-		delete(o.subs, who)
-	case sub.deposits <- proof:
-	}
+	bufsub.subs = subs
 }
 
 func (o *RPCOperator) PushBalanceProof(proof tee.BalanceProof) {
 	o.mtx.Lock()
 	defer o.mtx.Unlock()
 	who := proof.Balance.Account
-	sub, ok := o.subs[who]
+	bufsub, ok := o.subs[who]
 	if !ok {
 		log.WithField("who", who.Hex()).Debug("Received BP without subscription - buffering")
-		o.subscribe(who)
-		sub = o.subs[who]
+		bufsub = new(BufferedProofSubs)
+		o.subs[who] = bufsub
 	}
-	// Clear out old buffered proof.
-	select {
-	case <-sub.balances:
-	default:
+	bufsub.latestBP = &proof
+	subs := bufsub.subs
+
+	for i := 0; i < len(subs); i++ {
+		// Clear out old buffered proof.
+		select {
+		case <-subs[i].balances:
+		default:
+		}
+		// Write new proof in.
+		select {
+		case <-subs[i].quit:
+			l := len(subs) - 1
+			subs[i] = subs[l]
+			subs = subs[:l]
+			i--
+		case subs[i].balances <- proof:
+		}
 	}
-	// Write new proof in.
-	select {
-	case <-sub.quit:
-		delete(o.subs, who)
-	case sub.balances <- proof:
-	}
+	bufsub.subs = subs
 }
 
 // newProofSub returns a new proofSub. The proof channels have buffer size 1.
@@ -129,19 +162,19 @@ func newProofSub() *ProofSub {
 	}
 }
 
-func (sub *ProofSub) Deposits() <-chan tee.DepositProof {
+func (sub ProofSub) Deposits() <-chan tee.DepositProof {
 	return sub.deposits
 }
 
-func (sub *ProofSub) Balances() <-chan tee.BalanceProof {
+func (sub ProofSub) Balances() <-chan tee.BalanceProof {
 	return sub.balances
 }
 
-func (sub *ProofSub) Closed() <-chan struct{} {
+func (sub ProofSub) Closed() <-chan struct{} {
 	return sub.quit
 }
 
-func (sub *ProofSub) Unsubscribe() {
+func (sub ProofSub) Unsubscribe() {
 	select {
 	case <-sub.quit:
 	default:


### PR DESCRIPTION
The operator did not properly unsubscribe subscriptions, when a
connection was closed. Proof-Channels for subscriptions were
shared between multiple peer connections, thus resulting in pushing
proofs in a round-robin fashion.

We now multiplex proofs over all existing subscriptions.

Signed-off-by: Norbert Dzikowski <norbert@perun.network>